### PR TITLE
Pin ot-validator to 0.4.0 as advised via email from OT

### DIFF
--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -50,7 +50,7 @@ installValidator(){
   source $venvPath/ot-validator/bin/activate
   pip install --upgrade pip==18.1
   pip install --upgrade setuptools==40.6.2
-  pip install opentargets-validator==0.3.0
+  pip install opentargets-validator==0.4.0
   deactivate
 }
 


### PR DESCRIPTION
Sets the OT validator for the required version for May 2019 release.