### PR TITLE
Feature/get atlas data from staging

### DIFF
--- a/bin/RUV_normalisation_BluePrint.R
+++ b/bin/RUV_normalisation_BluePrint.R
@@ -40,7 +40,7 @@ for (i in names(t)) {
 }
 
 ## sanity check 
-head(all)
+colnames(all)
 dim(all)
 
 all_blueprint<-all

--- a/bin/RUV_normalisation_BluePrint.R
+++ b/bin/RUV_normalisation_BluePrint.R
@@ -2,13 +2,13 @@
 
 # Author: Suhaib Mohammed
 
-suppressMessages( library( ExpressionAtlas) )
 suppressMessages( library( funr ) )
 
 script_path<-funr::get_script_path()
 
 ## loading generic functions 
 source(paste(script_path,"generic_functions.R",sep="/"))
+source(paste(script_path,"get_data_from_staging.R",sep="/"))
 
 # Get commandline arguments.
 args <- commandArgs( TRUE )

--- a/bin/RUV_normalisation_gtex.R
+++ b/bin/RUV_normalisation_gtex.R
@@ -43,7 +43,7 @@ for (i in names(t)) {
 }
 
 ## sanity check 
-head(all)
+colnames(all)
 dim(all)
 
 x<-sapply(strsplit(colnames(all),split="_"),"[",3)

--- a/bin/RUV_normalisation_gtex.R
+++ b/bin/RUV_normalisation_gtex.R
@@ -4,13 +4,13 @@
 
  ## parse study_list as `echo -e "E-MTAB-5214"'\t'"E-MTAB-513"'\t'"E-MTAB-2836"`
 
-suppressMessages( library( ExpressionAtlas) )
 suppressMessages( library( funr) )
 
 script_path<-funr::get_script_path()
 
 ## loading generic functions 
 source(paste(script_path,"generic_functions.R",sep="/"))
+source(paste(script_path,"get_data_from_staging.R",sep="/"))
 
 # Get commandline arguments.
 args <- commandArgs( TRUE )

--- a/bin/export_ot_baseline_metaanalysis.sh
+++ b/bin/export_ot_baseline_metaanalysis.sh
@@ -6,6 +6,7 @@ scriptDir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 [ ! -z ${BASELINE_META_DESTINATION+x} ] || ( echo "Env var BASELINE_META_DESTINATION path to the baseline baseline meta analysis directory needs to be defined." && exit 1 )
 [ ! -z ${BLUEPRINT_STUDIES+x} ] || ( echo "Env var BLUEPRINT_STUDIES comma separated blueprint baseline studies needs to be defined." && exit 1 )
 [ ! -z ${GTEX_STUDIES+x} ] || ( echo "Env var GTEX_STUDIES comma separated gtex baseline studies needs to be defined." && exit 1 )
+[ ! -z ${ATLAS_EXPS+x} ] || ( echo "Env var ATLAS_EXPS path to the staging directory needs to be defined." && exit 1 )
 
 
 export outpath_path=${BASELINE_META_DESTINATION}/output_$(date "+%Y-%m-%d")

--- a/bin/get_data_from_staging.R
+++ b/bin/get_data_from_staging.R
@@ -1,0 +1,165 @@
+#!/usr/bin/env Rscript
+  
+  # getAtlasExperiment
+  #   - Download and return the SimpleList object representing a single
+  #   Expression Atlas experiment.
+  getAtlasExperiment <- function( experimentAccession ) {
+    
+    # Make sure the experiment accession is in the correct format.
+    if( ! .isValidExperimentAccession( experimentAccession ) ) {
+      
+      stop( "Experiment accession not valid. Cannot continue." )
+    }
+    
+    # $ATLAS_EXPS to load Atlas data from.
+    ATLAS_EXPS <- Sys.getenv("ATLAS_EXPS")
+    
+    # Create filename for R data file.
+    atlasExperimentSummaryFile <- paste( 
+      experimentAccession,
+      "-atlasExperimentSummary.Rdata", 
+      sep = "" 
+    )
+    
+    # Create full path to download R data from.
+    fullPath <- paste( 
+      ATLAS_EXPS, 
+      experimentAccession, 
+      atlasExperimentSummaryFile, 
+      sep = "/" 
+    )
+    
+    message( 
+      paste( 
+        "Getting Expression Atlas experiment summary from:\n", 
+        fullPath
+      ) 
+    )
+  
+  # Try download, catching any errors
+  loadResult <- try( load( fullPath ), silent = TRUE )
+  
+  # Quit if we got an error.
+  if( class( loadResult ) == "try-error" ) {
+    msg <- geterrmessage()
+    
+    warning( 
+      paste( 
+        paste( 
+          "Error encountered while trying to load experiment summary for",
+          experimentAccession,
+          ":"
+        ),
+        msg,
+      )
+    )
+      return( )
+  }
+  
+  # Make sure experiment summary object exists before trying to return it.
+  getResult <- try( get( "experimentSummary" ) )
+  
+  if( class( getResult ) == "try-error" ) {
+    
+    stop( 
+      "ERROR - Loading appeared successful but no experiment summary object was found." 
+    )
+  }
+  
+  # If we're still here, things must have worked ok.
+  message( 
+    paste( 
+      "Successfully loaded experiment summary object for", 
+      experimentAccession
+    ) 
+  )
+  
+  # Return the experiment summary.
+  expSum <- get( "experimentSummary" )
+  
+  return( expSum )
+}
+  
+# .isValidExperimentAccession
+#   - Return TRUE if experiment accession matches expected ArrayExpress
+#   experiment accession pattern. Return FALSE otherwise.
+.isValidExperimentAccession <- function( experimentAccession ) {
+  
+  if( missing( experimentAccession ) ) {
+    
+    warning( "Accession missing. Cannot validate." )
+    
+    return( FALSE )
+  }
+  
+  if( !grepl( "^E-\\w{4}-\\d+$", experimentAccession ) ) {
+    
+    warning( 
+      paste( 
+        "\"", 
+        experimentAccession, 
+        "\" does not look like an ArrayExpress experiment accession. Please check.", 
+        sep="" 
+      ) 
+    )
+    
+    return( FALSE )
+    
+  } else {
+    
+    return( TRUE )
+  }
+}
+
+
+# getAtlasData
+#   - Download SimpleList objects for one or more Expression Atlas experiments
+#   and return then in a list.
+getAtlasData <- function( experimentAccessions ) {
+  
+  if( missing( experimentAccessions ) ) {
+    
+    stop( "Please provide a vector of experiment accessions to download." )
+  }
+  
+  # Make sure experimentAccessions is a vector.
+  if( ! is.vector( experimentAccessions ) ) {
+    
+    stop( "Please provide experiment accessions as a vector." )
+  }
+  
+  # Only use valid accessions to download.
+  experimentAccessions <- experimentAccessions[ 
+    which( 
+      sapply( 
+        experimentAccessions, function( accession ) {
+          .isValidExperimentAccession( accession )
+        }
+      )
+    )
+    ]
+  
+  # The experimentAccessions vector is empty if none of the accessions are
+  # valid. Just quit here if so.
+  if( length( experimentAccessions ) == 0 ) {
+    stop( "None of the accessions passed are valid ArrayExpress accessions. Cannot continue." )
+  }
+  
+  # Go through each one and download it, creating a list.
+  # So that the list has the experiment accessions as the names, use them as
+  # names for the vector before starting to create the list.
+  names( experimentAccessions ) <- experimentAccessions
+  
+  experimentSummaryList <- SimpleList( 
+    
+    lapply( experimentAccessions, function( experimentAccession ) {
+      
+      experimentSummary <- getAtlasExperiment( experimentAccession )
+    } 
+    ) )
+  
+  # Remove any null entries, i.e. experiments without R data files available.
+  experimentSummaryList <- experimentSummaryList[ ! sapply( experimentSummaryList, is.null ) ]
+  
+  return( experimentSummaryList )
+}

--- a/bin/get_data_from_staging.R
+++ b/bin/get_data_from_staging.R
@@ -1,5 +1,8 @@
 #!/usr/bin/env Rscript
   
+  suppressMessages( library(  S4Vectors ) )
+  suppressMessages( library(  SummarizedExperiment ) )
+
   # getAtlasExperiment
   #   - Download and return the SimpleList object representing a single
   #   Expression Atlas experiment.


### PR DESCRIPTION
In this PR
-  OT baseline meta-analysis to get Atlas R objects data from staging (ATLAS_EXPS) rather than FTP
-  CHEBI exports modification of perl scripts to fetch experiment title from webAPI as field in database is truncated
- Same as CHEBI for EBEYE exports retrieve title from webAPI

http://193.62.52.166:30752/jenkins/view/Bulk%20data%20exports/
All exports succeeded with queries migrating to staging-ATLAS_EXPS (OT) and WebAPI( chebi, ebeye)