### PR TITLE
Feature/ebye webapi

### DIFF
--- a/bin/create-ebeye-dump.sh
+++ b/bin/create-ebeye-dump.sh
@@ -19,5 +19,5 @@ if [ $? -ne 0 ]; then
     echo "ERROR: Failed to generate EB-eye dump"
     exit 1
 fi
-cp ebeye*.xml $ATLAS_EXPS
+cp ebeye*.xml $ATLAS_PROD/EBEYE_dumps
 popd

--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -289,7 +289,7 @@ sub fetch_degenes_experiments_contrasts_from_solrdb {
 }
 
 ## fetch json formatted result for experiments and its titles from WebAPI.
-sub fetch_experiment_title_from_webpapi {
+sub fetch_experiment_title_from_webapi {
 
     my ( $expAcc, $logger ) = @_;
 
@@ -735,13 +735,13 @@ sub get_and_write_experiments_info {
 
 	# populate $H_differentialExperimentsInfo with experiment titles for each differential study
 	foreach my $expAcc ( keys %{ $H_differentialExperimentsInfo } ) {
-		my $title = fetch_experiment_title_from_webpapi( $expAcc, $logger );
+		my $title = fetch_experiment_title_from_webapi( $expAcc, $logger );
         $H_differentialExperimentsInfo->{ $expAcc }->{ "title" } = $title;
 	} 
 
 	# populate $H_differentialExperimentsInfo with experiment titles for each baseline study
 	foreach my $expAcc ( keys %{ $H_baselineExperimentsInfo } ) {
-		my $title = fetch_experiment_title_from_webpapi( $expAcc, $logger );
+		my $title = fetch_experiment_title_from_webapi( $expAcc, $logger );
         $H_baselineExperimentsInfo->{ $expAcc }->{ "title" } = $title;
 	} 
 

--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -73,7 +73,7 @@ check_env_var('ATLAS_PROD');
 check_env_var('BIOENTITY_PROPERTIES_ENSEMBL',"\$ATLAS_PROD/bioentity_properties/annotations/ensembl");
 check_env_var('BIOENTITY_PROPERTIES_WBPS',"\$ATLAS_PROD/bioentity_properties/annotations/wbps");
 check_env_var('SOLR_HOST',"should include both host and port if needed.");
-
+check_env_var('WEB_API_URL',"should include api url.");
 
 my $atlasProdDir = $ENV{ "ATLAS_PROD" };
 my $bioentity_properties_annotations_ensembl=$ENV{'BIOENTITY_PROPERTIES_ENSEMBL'};
@@ -100,7 +100,7 @@ my $configHash = {
 	bioentityPropertiesEnsemblDir => $bioentity_properties_annotations_ensembl,
 
     # Directory where <species>.wbpsgene.tsv files are.
-  bioentityPropertiesWBPSDir => $bioentity_properties_annotations_wbps,
+  	bioentityPropertiesWBPSDir => $bioentity_properties_annotations_wbps,
 
 	# Filename for differential Atlas data.
 	differentialDataFilename => "ebeye_differential_genes_export.xml",
@@ -293,27 +293,27 @@ sub fetch_experiment_title_from_webapi {
 
     my ( $expAcc, $logger ) = @_;
 
-    my $url = "https://wwwdev.ebi.ac.uk/gxa/json/experiments";
+    my $url = $ENV{'WEB_API_URL'};
 
     my $json_hash;
     my $expTitle;
 
-        my $abs_url = join("/",$url,$expAcc);
-        my $ua = LWP::UserAgent->new;
-        my $response;
-        $response =  $ua->get($abs_url);
-        $logger->info( "Querying for experiment titles for $expAcc" );
+    my $abs_url = join("/",$url,$expAcc);
+    my $ua = LWP::UserAgent->new;
+    my $response;
+    $response =  $ua->get($abs_url);
+    $logger->info( "Querying for experiment titles for $expAcc" );
 
-        if ($response->is_success) {
-            $json_hash = parse_json(decode ('UTF-8', $response->content));
-        }
-        else {
-         die $response->status_line;
-        }
+    if ($response->is_success) {
+    	$json_hash = parse_json(decode ('UTF-8', $response->content));
+    }
+    else {
+    	die $response->status_line;
+    }
 
-        $expTitle = $json_hash->{'experiment'}->{'description'};
+    $expTitle = $json_hash->{'experiment'}->{'description'};
 
-   return $expTitle;
+    return $expTitle;
 }
 
 # get_and_write_expression_data_xml
@@ -736,13 +736,13 @@ sub get_and_write_experiments_info {
 	# populate $H_differentialExperimentsInfo with experiment titles for each differential study
 	foreach my $expAcc ( keys %{ $H_differentialExperimentsInfo } ) {
 		my $title = fetch_experiment_title_from_webapi( $expAcc, $logger );
-        $H_differentialExperimentsInfo->{ $expAcc }->{ "title" } = $title;
+		$H_differentialExperimentsInfo->{ $expAcc }->{ "title" } = $title;
 	} 
 
 	# populate $H_differentialExperimentsInfo with experiment titles for each baseline study
 	foreach my $expAcc ( keys %{ $H_baselineExperimentsInfo } ) {
 		my $title = fetch_experiment_title_from_webapi( $expAcc, $logger );
-        $H_baselineExperimentsInfo->{ $expAcc }->{ "title" } = $title;
+		$H_baselineExperimentsInfo->{ $expAcc }->{ "title" } = $title;
 	} 
 
     # Disconnect from Atlas DB.

--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -731,15 +731,15 @@ sub get_and_write_experiments_info {
 	# Run the queries to create two hashes, one with info for baseline
 	# experiments and one with info for differential experiments.
     my $H_differentialExperimentsInfo = $atlasDB->fetch_differential_experiment_info_from_atlasdb( $logger );
-	my $H_baselineExperimentsInfo = $atlasDB->fetch_baseline_experiment_info_from_atlasdb( $logger );
+    my $H_baselineExperimentsInfo = $atlasDB->fetch_baseline_experiment_info_from_atlasdb( $logger );
 
-	# populate $H_differentialExperimentsInfo with experiment titls for each differential study
+	# populate $H_differentialExperimentsInfo with experiment titles for each differential study
 	foreach my $expAcc ( keys %{ $H_differentialExperimentsInfo } ) {
 		my $title = fetch_experiment_title_from_webpapi( $expAcc, $logger );
         $H_differentialExperimentsInfo->{ $expAcc }->{ "title" } = $title;
 	} 
 
-	# populate $H_differentialExperimentsInfo with experiment title for each baseline study
+	# populate $H_differentialExperimentsInfo with experiment titles for each baseline study
 	foreach my $expAcc ( keys %{ $H_baselineExperimentsInfo } ) {
 		my $title = fetch_experiment_title_from_webpapi( $expAcc, $logger );
         $H_baselineExperimentsInfo->{ $expAcc }->{ "title" } = $title;


### PR DESCRIPTION
In this PR,
- EBEYE export 
 -The function to fetch experiment titles from WebAPI introduced in `export_atlas_ebeye_xml.pl`  as it was removed from perl module `pgGXA.pm`
 -Export of EBYE dump to be copied into new location under `$ATLAS_PROD` rather than `$ATLAS_EXPS`

I tested the changes in feature branch https://github.com/ebi-gene-expression-group/atlas-prod/pull/140

Output in Jenkins
http://193.62.52.166:30752/jenkins/view/Bulk%20data%20exports/job/C_EBEYE_Export_test/1/console


