### PR TITLE
single cell atlas EBEYE S4 baseline studies

### DIFF
--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -543,8 +543,6 @@ sub get_and_write_expression_data_xml {
 				}
 				# Join the factor and value strings with "; ".
 				my $joinedFactorsValues = join "; ", @factorValueStrings;
-				# Add this to the description.
-				$diffDesc .= $joinedFactorsValues;
 
 				# Add differential description element.
 				$differentialWriter->dataElement("description" => $diffDesc);
@@ -598,8 +596,6 @@ sub get_and_write_expression_data_xml {
 				}
 				# Join the factor and value strings with "; ".
 				my $joinedFactorsValues = join "; ", @factorValueStrings;
-				# Add this to the description.
-				$baselineDesc .= $joinedFactorsValues;
 
 				# Add baseline description element
 				$baselineWriter->dataElement("description" => $baselineDesc);

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -1,0 +1,224 @@
+#!/usr/bin/env perl
+## export WEB_API_URL="https://wwwdev.ebi.ac.uk/gxa/sc/json/experiments"
+
+use strict;
+use warnings;
+
+use XML::Writer;
+use IO::File;
+use DateTime;
+use LWP::UserAgent;
+use HTTP::Request::Common;
+use LWP::Simple;
+use XML::Simple qw( :strict );
+use File::Basename;
+use File::Spec;
+use Log::Log4perl;
+use JSON::Parse qw( parse_json );
+use Encode qw(
+    encode
+    decode
+);
+
+use Atlas::Common qw(
+	connect_pg_atlas
+	create_atlas_site_config
+	get_atlas_contrast_details
+	get_log_file_header
+	get_log_file_name
+);
+
+# Flush buffer after every print.
+$| = 1;
+
+
+# Config for logger.
+my $logger_config = q(
+	log4perl.rootlogger					= INFO, LOG1, SCREEN
+	log4perl.appender.SCREEN			= Log::Log4perl::Appender::Screen
+	log4perl.appender.SCREEN.stderr		= 0
+	log4perl.appender.SCREEN.layout		= Log::Log4perl::Layout::PatternLayout
+	log4perl.appender.SCREEN.layout.ConversionPattern = %-5p - %m%n
+	log4perl.appender.LOG1				= Log::Log4perl::Appender::File
+	log4perl.appender.LOG1.filename		= sub { get_log_file_name( "export_atlas_ebeye_xml" ) }
+	log4perl.appender.LOG1.header_text	= sub { get_log_file_header( "Atlas EB-eye XML dump" ) }
+	log4perl.appender.LOG1.mode			= append
+	log4perl.appender.LOG1.layout		= Log::Log4perl::Layout::PatternLayout
+	log4perl.appender.LOG1.layout.ConversionPattern = %-5p - %m%n
+);
+
+# Initialise logger.
+Log::Log4perl::init( \$logger_config );
+my $logger = Log::Log4perl::get_logger;
+
+# The date in dd-mmm-yyyy format e.g. 14-Nov-2013
+my $today = DateTime->today();
+my $date = $today->day()."-".$today->month_abbr()."-".$today->year();
+
+
+sub check_env_var {
+  my $var = shift;
+  my $suggestion = shift;
+
+  unless(defined $ENV{$var}) {
+    $logger->error( "Please define $var env var" );
+    $logger->info( "Usually for $var: $suggestion" ) if(defined $suggestion);
+    exit 1;
+  }
+}
+
+
+check_env_var('ATLAS_PROD');
+check_env_var('WEB_API_URL',"should include api url.");
+
+my $atlasProdDir = $ENV{ "ATLAS_PROD" };
+
+# A hash to store some config for things we might want to change later, at the
+# top so it's easy to find.
+my $configHash = {
+	
+	# Today's date.
+	today => $date,
+
+	# Filename for baselie Atlas experiments info.
+	baselineExperimentsFilename => "ebeye_sc_baseline_experiments_export.xml ",
+
+	# A description of Atlas. This will go at the top of the XML.
+	atlasDescription => "A semantically enriched database of publicly available single cell gene and transcript expression data. The data is re-analysed in-house to detect genes showing interesting baseline expression patterns under the conditions of the original experiment.",
+
+};
+
+
+my $H_baselineExperimentsInfo = fetch_experiments_info_from_webapi($logger);
+
+
+# Get info from webAPI and write XMLs for baseline experiment info.
+get_and_write_experiments_info($configHash, $H_baselineExperimentsInfo);
+
+
+## fetch json formatted result for experiments and its titles from WebAPI.
+sub fetch_experiments_info_from_webapi {
+
+    my ( $logger ) = @_;
+
+    my $url = $ENV{'WEB_API_URL'};
+
+    my $json_hash;
+
+    my $abs_url = join("/",$url);
+    my $ua = LWP::UserAgent->new;
+    my $response;
+    $response =  $ua->get($abs_url);
+    $logger->info( "Querying for single cell experiments from web API" );
+
+    if ($response->is_success) {
+    	$json_hash = parse_json(decode ('UTF-8', $response->content));
+    }
+    else {
+    	die $response->status_line;
+    }
+
+    return $json_hash;
+}
+
+
+
+
+# get_and_write_experiments_info
+# 	- Retrieve differential and baseline experiments information from Atlas
+# 	database and write it to XML dump files (differential to one, baseline to
+# 	another).
+sub get_and_write_experiments_info {
+	my ($configHash, $H_baselineExperimentsInfo) = @_;
+
+	# Files to write XML to.
+	# Baseline data.
+	my $baselineExperimentsFilename = $configHash->{ "baselineExperimentsFilename" };
+	my $baselineExperimentsEBeyeXML = IO::File->new(">$baselineExperimentsFilename");
+
+	# A description of Atlas. This will go at the top of the XML.
+	my $atlasDescription = $configHash->{ "atlasDescription" };
+
+	# New XML writers with newlines and nice indentation.
+	# Baseline one.
+	my $baselineExperimentsWriter = XML::Writer->new(OUTPUT => $baselineExperimentsEBeyeXML, DATA_MODE => 1, DATA_INDENT => 4);
+
+	# Today's date.
+	my $date_string = $configHash->{ "today" };
+
+	# Begin XML
+	foreach my $writer ($baselineExperimentsWriter) {
+		$writer->xmlDecl("UTF-8");
+		$writer->startTag("database");
+		$writer->dataElement("name" => "SingleCellExpressionAtlas");
+		$writer->dataElement("description" => $atlasDescription);
+		$writer->emptyTag("release");
+		$writer->dataElement("release_date" => $date_string);
+	}
+
+	# Count the number of experiments for each type.
+	my $baselineExperimentsCount = ( scalar (@{ $H_baselineExperimentsInfo->{'experiments'}}) );
+	$baselineExperimentsWriter->dataElement("entry_count" => $baselineExperimentsCount);
+
+	# Start the "entries" element.
+	foreach my $writer ($baselineExperimentsWriter) {
+		$writer->startTag("entries");
+	}
+
+	# Write the baseline experiments info.
+	add_experiments_info($baselineExperimentsWriter, $H_baselineExperimentsInfo);
+
+	# Close entries and database elements for both writers.
+	foreach my $writer ($baselineExperimentsWriter) {
+		$writer->endTag("entries");
+		$writer->endTag("database");
+		$writer->end();
+	}
+
+	# Close files.
+	$baselineExperimentsEBeyeXML->close();
+
+	# Log that we're done.
+	$logger->info( "Baseline SC Expression Atlas EB-eye experiments info exported to $baselineExperimentsFilename" );
+}
+
+
+# add_experiments_info
+# 	- Write XML using experiments info from Atlas database.
+sub add_experiments_info {
+	my ($writer, $H_experimentsInfo) = @_;
+
+	foreach my $hash_ref ( @{ $H_baselineExperimentsInfo->{'experiments'} } ){
+ 		my $exptAcc = $hash_ref->{'experimentAccession'};
+
+		# Start the entry for this experiment.
+		# Add the accession as the "id".
+		$writer->startTag("entry", "id" => $exptAcc);
+
+		# Add the accession as the "name".
+		$writer->dataElement("name" => $exptAcc);
+
+		# Add the title as the "description".
+		$writer->dataElement("description" => $hash_ref->{ "experimentDescription" });
+
+		# Add the date as "creation" date, "last_modification" and publication" date.
+		$writer->startTag("dates");
+
+		# format datefield to exclude any time stamps and retain only date
+		my $dateformat=($hash_ref->{ "lastUpdate" });
+
+		$writer->emptyTag("date", "type" => "creation", "value" => $dateformat);
+		$writer->emptyTag("date", "type" => "last_modification", "value" => $dateformat);
+		$writer->emptyTag("date", "type" => "publication", "value" => $dateformat);
+		$writer->endTag("dates");
+
+		# Start the "cross_references" element and add the accession as
+		# ArrayExpress cross-reference.
+		$writer->startTag("cross_references");
+		$writer->emptyTag("ref", "dbname" => "arrayexpress", "dbkey" => $exptAcc);
+		$writer->endTag;
+
+		# End this entry.
+		$writer->endTag("entry");
+	}
+}

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -195,7 +195,7 @@ sub add_species_name {
     foreach my $exptAcc ( keys %{ $H_baselineExperimentGeneInfo->{ $geneID } }){
 
       $species_name =  $H_baselineExperimentGeneInfo->{ $geneID }->{ $exptAcc }->{ 'species' };
-      print $species_name . "\n";
+    
     }
       # Add gene associated species name
       $writer->dataElement("name" => $species_name);

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -205,24 +205,28 @@ sub add_experiments_info {
 
   # Add the title as the "description".
   $writer->dataElement("description" => $hash_ref->{ "experimentDescription" });
+
+  $writer->startTag("additional_fields");
   
-  $writer->dataElement("species" => $hash_ref->{ "species" });
+  $writer->dataElement("field" => $hash_ref->{ "species" }, "name" => "species" );
 
-  $writer->dataElement("technology" => @{ $hash_ref->{ "technologyType" } });
-
+  $writer->dataElement("field" => @{$hash_ref->{ "technologyType"}}, "name" => "technology");
+  
   ## factors included in each experiment
     foreach my $factor (@{ $hash_ref->{ "experimentalFactors" } }){
-         $writer->dataElement("factors" => $factor);
+         $writer->dataElement("field" => $factor, "name" => "factors" );
     }
   ## cell types included in each experiment
     foreach my $celltype (@{ $H_baselineCellTypeInfo->{ $exptAcc } }){
-         $writer->dataElement("celltype" => $celltype);
+         $writer->dataElement("field" => $celltype, "name" => "celltype" );
     }
 
   ## collections included in each experiment
     foreach my $collection (@{ $H_baselineCollectionInfo->{ $exptAcc } }){
-         $writer->dataElement("collection" => $collection);
+         $writer->dataElement("field" => $collection, "name" => "collection" );
     }
+
+  $writer->endTag("additional_fields");
 
   # Add the date as "creation" date, "last_modification" and publication" date.
   $writer->startTag("dates");

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -173,13 +173,32 @@ sub add_gene_info {
      
      $baselineWriter->startTag("entry", "id" => $geneID );
 
-      add_shared_cross_references( $baselineWriter, $geneID, $H_baselineExperimentGeneInfo);
+      # Add the species_name
+      add_species_name( $baselineWriter, $geneID, $H_baselineExperimentGeneInfo );
 
-      add_shared_additional_fields ($baselineWriter, $geneID,  $H_baselineExperimentGeneInfo);
+      add_shared_cross_references( $baselineWriter, $geneID, $H_baselineExperimentGeneInfo );
+
+      add_shared_additional_fields ( $baselineWriter, $geneID,  $H_baselineExperimentGeneInfo );
   
     $baselineWriter->endTag("entry");
 
   }
+
+}
+
+sub add_species_name {
+
+    my ( $writer, $geneID, $H_baselineExperimentGeneInfo ) = @_;
+
+    my $species_name;
+
+    foreach my $exptAcc ( keys %{ $H_baselineExperimentGeneInfo->{ $geneID } }){
+
+      $species_name =  $H_baselineExperimentGeneInfo->{ $geneID }->{ $exptAcc }->{ 'species' };
+      print $species_name . "\n";
+    }
+      # Add gene associated species name
+      $writer->dataElement("name" => $species_name);
 
 }
 

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -74,6 +74,10 @@ check_env_var('ATLAS_PROD');
 check_env_var('WEB_API_URL',"should include api url.");
 check_env_var('MARKER_GENE_PVAL',"should include pval threshold.");
 check_env_var('SOLR_HOST',"should include solr host.");
+check_env_var('SC_PG_DSN',"should include pg database dsn.");
+check_env_var('SC_PG_USERNAME',"should include pg database username.");
+check_env_var('SC_PG_PASSWORD',"should include pg database password.");
+
 
 my $atlasProdDir = $ENV{ "ATLAS_PROD" };
 

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -21,11 +21,12 @@ use Encode qw(
 );
 
 use Atlas::Common qw(
-	connect_pg_atlas
-	create_atlas_site_config
-	get_atlas_contrast_details
-	get_log_file_header
-	get_log_file_name
+ connect_pg_atlas
+ connect_sc_pg_atlas
+ create_atlas_site_config
+ get_atlas_contrast_details
+ get_log_file_header
+ get_log_file_name
 );
 
 # Flush buffer after every print.
@@ -34,17 +35,17 @@ $| = 1;
 
 # Config for logger.
 my $logger_config = q(
-	log4perl.rootlogger					= INFO, LOG1, SCREEN
-	log4perl.appender.SCREEN			= Log::Log4perl::Appender::Screen
-	log4perl.appender.SCREEN.stderr		= 0
-	log4perl.appender.SCREEN.layout		= Log::Log4perl::Layout::PatternLayout
-	log4perl.appender.SCREEN.layout.ConversionPattern = %-5p - %m%n
-	log4perl.appender.LOG1				= Log::Log4perl::Appender::File
-	log4perl.appender.LOG1.filename		= sub { get_log_file_name( "export_atlas_ebeye_xml" ) }
-	log4perl.appender.LOG1.header_text	= sub { get_log_file_header( "Atlas EB-eye XML dump" ) }
-	log4perl.appender.LOG1.mode			= append
-	log4perl.appender.LOG1.layout		= Log::Log4perl::Layout::PatternLayout
-	log4perl.appender.LOG1.layout.ConversionPattern = %-5p - %m%n
+ log4perl.rootlogger     = INFO, LOG1, SCREEN
+ log4perl.appender.SCREEN   = Log::Log4perl::Appender::Screen
+ log4perl.appender.SCREEN.stderr  = 0
+ log4perl.appender.SCREEN.layout  = Log::Log4perl::Layout::PatternLayout
+ log4perl.appender.SCREEN.layout.ConversionPattern = %-5p - %m%n
+ log4perl.appender.LOG1    = Log::Log4perl::Appender::File
+ log4perl.appender.LOG1.filename  = sub { get_log_file_name( "export_atlas_ebeye_xml" ) }
+ log4perl.appender.LOG1.header_text = sub { get_log_file_header( "Atlas EB-eye XML dump" ) }
+ log4perl.appender.LOG1.mode   = append
+ log4perl.appender.LOG1.layout  = Log::Log4perl::Layout::PatternLayout
+ log4perl.appender.LOG1.layout.ConversionPattern = %-5p - %m%n
 );
 
 # Initialise logger.
@@ -76,25 +77,48 @@ my $atlasProdDir = $ENV{ "ATLAS_PROD" };
 # A hash to store some config for things we might want to change later, at the
 # top so it's easy to find.
 my $configHash = {
-	
-	# Today's date.
-	today => $date,
+ 
+ # Today's date.
+ today => $date,
 
-	# Filename for baselie Atlas experiments info.
-	baselineExperimentsFilename => "ebeye_sc_baseline_experiments_export.xml ",
+ # Filename for baselie Atlas experiments info.
+ baselineExperimentsFilename => "ebeye_sc_baseline_experiments_export.xml ",
 
-	# A description of Atlas. This will go at the top of the XML.
-	atlasDescription => "A semantically enriched database of publicly available single cell gene and transcript expression data. The data is re-analysed in-house to detect genes showing interesting baseline expression patterns under the conditions of the original experiment.",
+ # A description of Atlas. This will go at the top of the XML.
+ atlasDescription => "A semantically enriched database of publicly available single cell gene and transcript expression data. The data is re-analysed in-house to detect genes showing interesting baseline expression patterns under the conditions of the original experiment.",
 
 };
 
 
 my $H_baselineExperimentsInfo = fetch_experiments_info_from_webapi($logger);
 
+# Connect to SC Atlas database.
+ my $atlasDB = connect_sc_pg_atlas;
+ 
+ my @array=('E-MTAB-7078','E-HCAD-9','E-MTAB-');
+ my $accessions=\@array;
+ #my $accessions='E-MTAB-7078';
+ my $H_baselineCellTypeInfo = $atlasDB->fetch_experiment_celltypes_from_sc_atlasdb( $logger );
+ my $H_baselineCollectionInfo = $atlasDB->fetch_experiments_collections_from_sc_atlasdb( $logger);
+ 
+ use Data::Dumper;
+   my $accessions4query = "'" . join( "', '", @{ $accessions } ) . "'";
+
+    my $query = "
+        SELECT distinct EXPERIMENT_ACCESSION, VALUE FROM SCXA_CELL_GROUP
+        WHERE EXPERIMENT_ACCESSION in ($accessions4query) and
+        VARIABLE like '%cell%' and VALUE !='Not available'";
+
+ print Dumper "accessions - $accessions \n";
+ print Dumper "accessions4query - $accessions4query \n"; 
+ print Dumper $query."\n";
+ print Dumper $H_baselineCellTypeInfo;
+ print Dumper $H_baselineCollectionInfo; 
+
+#print Dumper $H_baselineExperimentsInfo;
 
 # Get info from webAPI and write XMLs for baseline experiment info.
-get_and_write_experiments_info($configHash, $H_baselineExperimentsInfo);
-
+get_and_write_experiments_info($configHash, $H_baselineExperimentsInfo, $H_baselineCellTypeInfo, $H_baselineCollectionInfo);
 
 ## fetch json formatted result for experiments and its titles from WebAPI.
 sub fetch_experiments_info_from_webapi {
@@ -112,113 +136,128 @@ sub fetch_experiments_info_from_webapi {
     $logger->info( "Querying for single cell experiments from web API" );
 
     if ($response->is_success) {
-    	$json_hash = parse_json(decode ('UTF-8', $response->content));
+     $json_hash = parse_json(decode ('UTF-8', $response->content));
     }
     else {
-    	die $response->status_line;
+     die $response->status_line;
     }
 
     return $json_hash;
 }
 
-
-
-
 # get_and_write_experiments_info
-# 	- Retrieve differential and baseline experiments information from Atlas
-# 	database and write it to XML dump files (differential to one, baseline to
-# 	another).
+#  - Retrieve differential and baseline experiments information from Atlas
+#  database and write it to XML dump files (differential to one, baseline to
+#  another).
 sub get_and_write_experiments_info {
-	my ($configHash, $H_baselineExperimentsInfo) = @_;
+ my ($configHash, $H_baselineExperimentsInfo, $H_baselineCellTypeInfo) = @_;
 
-	# Files to write XML to.
-	# Baseline data.
-	my $baselineExperimentsFilename = $configHash->{ "baselineExperimentsFilename" };
-	my $baselineExperimentsEBeyeXML = IO::File->new(">$baselineExperimentsFilename");
+ # Files to write XML to.
+ # Baseline data.
+ my $baselineExperimentsFilename = $configHash->{ "baselineExperimentsFilename" };
+ my $baselineExperimentsEBeyeXML = IO::File->new(">$baselineExperimentsFilename");
 
-	# A description of Atlas. This will go at the top of the XML.
-	my $atlasDescription = $configHash->{ "atlasDescription" };
+ # A description of Atlas. This will go at the top of the XML.
+ my $atlasDescription = $configHash->{ "atlasDescription" };
 
-	# New XML writers with newlines and nice indentation.
-	# Baseline one.
-	my $baselineExperimentsWriter = XML::Writer->new(OUTPUT => $baselineExperimentsEBeyeXML, DATA_MODE => 1, DATA_INDENT => 4);
+ # New XML writers with newlines and nice indentation.
+ # Baseline one.
+ my $baselineExperimentsWriter = XML::Writer->new(OUTPUT => $baselineExperimentsEBeyeXML, DATA_MODE => 1, DATA_INDENT => 4);
 
-	# Today's date.
-	my $date_string = $configHash->{ "today" };
+ # Today's date.
+ my $date_string = $configHash->{ "today" };
 
-	# Begin XML
-	foreach my $writer ($baselineExperimentsWriter) {
-		$writer->xmlDecl("UTF-8");
-		$writer->startTag("database");
-		$writer->dataElement("name" => "SingleCellExpressionAtlas");
-		$writer->dataElement("description" => $atlasDescription);
-		$writer->emptyTag("release");
-		$writer->dataElement("release_date" => $date_string);
-	}
+ # Begin XML
+ foreach my $writer ($baselineExperimentsWriter) {
+  $writer->xmlDecl("UTF-8");
+  $writer->startTag("database");
+  $writer->dataElement("name" => "SingleCellExpressionAtlas");
+  $writer->dataElement("description" => $atlasDescription);
+  $writer->emptyTag("release");
+  $writer->dataElement("release_date" => $date_string);
+ }
 
-	# Count the number of experiments for each type.
-	my $baselineExperimentsCount = ( scalar (@{ $H_baselineExperimentsInfo->{'experiments'}}) );
-	$baselineExperimentsWriter->dataElement("entry_count" => $baselineExperimentsCount);
+ # Count the number of experiments for each type.
+ my $baselineExperimentsCount = ( scalar (@{ $H_baselineExperimentsInfo->{'experiments'}}) );
+ $baselineExperimentsWriter->dataElement("entry_count" => $baselineExperimentsCount);
 
-	# Start the "entries" element.
-	foreach my $writer ($baselineExperimentsWriter) {
-		$writer->startTag("entries");
-	}
+ # Start the "entries" element.
+ foreach my $writer ($baselineExperimentsWriter) {
+  $writer->startTag("entries");
+ }
 
-	# Write the baseline experiments info.
-	add_experiments_info($baselineExperimentsWriter, $H_baselineExperimentsInfo);
+ # Write the baseline experiments info.
+ add_experiments_info($baselineExperimentsWriter, $H_baselineExperimentsInfo, $H_baselineCellTypeInfo, $H_baselineCollectionInfo);
 
-	# Close entries and database elements for both writers.
-	foreach my $writer ($baselineExperimentsWriter) {
-		$writer->endTag("entries");
-		$writer->endTag("database");
-		$writer->end();
-	}
+ # Close entries and database elements for both writers.
+ foreach my $writer ($baselineExperimentsWriter) {
+  $writer->endTag("entries");
+  $writer->endTag("database");
+  $writer->end();
+ }
 
-	# Close files.
-	$baselineExperimentsEBeyeXML->close();
+ # Close files.
+ $baselineExperimentsEBeyeXML->close();
 
-	# Log that we're done.
-	$logger->info( "Baseline SC Expression Atlas EB-eye experiments info exported to $baselineExperimentsFilename" );
+ # Log that we're done.
+ $logger->info( "Baseline SC Expression Atlas EB-eye experiments info exported to $baselineExperimentsFilename" );
 }
 
 
 # add_experiments_info
-# 	- Write XML using experiments info from Atlas database.
+#  - Write XML using experiments info from Atlas database.
 sub add_experiments_info {
-	my ($writer, $H_experimentsInfo) = @_;
+ my ($writer, $H_baselineExperimentsInfo, $H_baselineCellTypeInfo, $H_baselineCollectionInfo) = @_;
 
-	foreach my $hash_ref ( @{ $H_baselineExperimentsInfo->{'experiments'} } ){
- 		my $exptAcc = $hash_ref->{'experimentAccession'};
+ foreach my $hash_ref ( @{ $H_baselineExperimentsInfo->{'experiments'} } ){
+   my $exptAcc = $hash_ref->{'experimentAccession'};
+  
+  # Start the entry for this experiment.
+  # Add the accession as the "id".
+  $writer->startTag("entry", "id" => $exptAcc);
 
-		# Start the entry for this experiment.
-		# Add the accession as the "id".
-		$writer->startTag("entry", "id" => $exptAcc);
+  # Add the accession as the "name".
+  $writer->dataElement("name" => $exptAcc);
 
-		# Add the accession as the "name".
-		$writer->dataElement("name" => $exptAcc);
+  # Add the title as the "description".
+  $writer->dataElement("description" => $hash_ref->{ "experimentDescription" });
+  
+  $writer->dataElement("species" => $hash_ref->{ "species" });
 
-		# Add the title as the "description".
-		$writer->dataElement("description" => $hash_ref->{ "experimentDescription" });
+  $writer->dataElement("technology" => @{ $hash_ref->{ "technologyType" } });
 
-		# Add the date as "creation" date, "last_modification" and publication" date.
-		$writer->startTag("dates");
+  ## factors included in each experiment
+    foreach my $factor (@{ $hash_ref->{ "experimentalFactors" } }){
+         $writer->dataElement("factors" => $factor);
+    }
+  ## cell types included in each experiment
+    foreach my $celltype (@{ $H_baselineCellTypeInfo->{ $exptAcc } }){
+         $writer->dataElement("celltype" => $celltype);
+    }
 
-		# format datefield to exclude any time stamps and retain only date
-		my $dateformat=($hash_ref->{ "lastUpdate" });
+  ## collections included in each experiment
+    foreach my $collection (@{ $H_baselineCollectionInfo->{ $exptAcc } }){
+         $writer->dataElement("collection" => $collection);
+    }
 
-		$writer->emptyTag("date", "type" => "creation", "value" => $dateformat);
-		$writer->emptyTag("date", "type" => "last_modification", "value" => $dateformat);
-		$writer->emptyTag("date", "type" => "publication", "value" => $dateformat);
-		$writer->endTag("dates");
+  # Add the date as "creation" date, "last_modification" and publication" date.
+  $writer->startTag("dates");
 
-		# Start the "cross_references" element and add the accession as
-		# ArrayExpress cross-reference.
-		$writer->startTag("cross_references");
-		$writer->emptyTag("ref", "dbname" => "arrayexpress", "dbkey" => $exptAcc);
-		$writer->endTag;
+  # format datefield to exclude any time stamps and retain only date
+  my $dateformat=($hash_ref->{ "lastUpdate" });
 
-		# End this entry.
-		$writer->endTag("entry");
-	}
+  $writer->emptyTag("date", "type" => "creation", "value" => $dateformat);
+  $writer->emptyTag("date", "type" => "last_modification", "value" => $dateformat);
+  $writer->emptyTag("date", "type" => "publication", "value" => $dateformat);
+  $writer->endTag("dates");
+
+  # Start the "cross_references" element and add the accession as
+  # ArrayExpress cross-reference.
+  $writer->startTag("cross_references");
+  $writer->emptyTag("ref", "dbname" => "arrayexpress", "dbkey" => $exptAcc);
+  $writer->endTag;
+
+  # End this entry.
+  $writer->endTag("entry");
+ }
 }

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -121,6 +121,26 @@ get_and_write_genes_info( $configHash, $H_baselineExperimentGeneInfo, $H_baselin
 add_entry_count ( $configHash );
 
 
+## parse json formatted result for genes associated to experiments accessions and assay group ids.
+sub parse_json_from_solr {
+
+   my ( $url, $logger ) =  @_;
+   my $ua = LWP::UserAgent->new;
+
+   my $response;
+   $response =  $ua->request(GET "$url");
+
+    $logger->info( "response successful." );
+
+   my $json_hash = parse_json(decode ('UTF-8', $response->content));
+
+     $logger->info( "parsing json successful." );
+
+   my $array_ref = $json_hash->{'response'}->{'docs'};
+
+   return $array_ref;
+}
+
 sub get_and_write_genes_info {
 
  my ($configHash, $H_baselineExperimentGeneInfo, $H_baselineExperimentsInfo, $GeneNames_ref ) = @_;
@@ -198,7 +218,7 @@ sub add_gene_name {
     foreach my $hash_ref ( @{ $GeneNames_ref } ){
 
         if ( $hash_ref->{'bioentity_identifier'} eq "$geneID" ){
-          
+
            my $gene_symbol = $hash_ref->{'property_value'};
 
            #Add the accession as the "gene name".
@@ -263,7 +283,7 @@ sub add_shared_additional_fields {
     $writer->dataElement("field" => $baselineExptCount, "name" => "studies_count" );
 
     # Add the species_name
-    add_species_name( $baselineWriter, $geneID, $H_baselineExperimentGeneInfo );
+    add_species_name( $writer, $geneID, $H_baselineExperimentGeneInfo );
 
     foreach my $expAcc ( keys %{ $H_baselineExperimentGeneInfo->{ $geneID } }){
 

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -73,6 +73,8 @@ sub check_env_var {
 
 check_env_var('ATLAS_PROD');
 check_env_var('WEB_API_URL',"should include api url.");
+check_env_var('CPM_THRESHOLD',"should include CPM threshold.");
+check_env_var('TPM_THRESHOLD',"should include TPM threshold.");
 
 my $atlasProdDir = $ENV{ "ATLAS_PROD" };
 

--- a/bin/export_sc_atlas_ebeye_xml.pl
+++ b/bin/export_sc_atlas_ebeye_xml.pl
@@ -93,30 +93,14 @@ my $configHash = {
 my $H_baselineExperimentsInfo = fetch_experiments_info_from_webapi($logger);
 
 # Connect to SC Atlas database.
- my $atlasDB = connect_sc_pg_atlas;
+my $atlasDB = connect_sc_pg_atlas;
+
+# Fetch cell types from db
+my $H_baselineCellTypeInfo = $atlasDB->fetch_experiment_celltypes_from_sc_atlasdb( $logger );
+
+# Fetch collections from db
+my $H_baselineCollectionInfo = $atlasDB->fetch_experiments_collections_from_sc_atlasdb( $logger);
  
- my @array=('E-MTAB-7078','E-HCAD-9','E-MTAB-');
- my $accessions=\@array;
- #my $accessions='E-MTAB-7078';
- my $H_baselineCellTypeInfo = $atlasDB->fetch_experiment_celltypes_from_sc_atlasdb( $logger );
- my $H_baselineCollectionInfo = $atlasDB->fetch_experiments_collections_from_sc_atlasdb( $logger);
- 
- use Data::Dumper;
-   my $accessions4query = "'" . join( "', '", @{ $accessions } ) . "'";
-
-    my $query = "
-        SELECT distinct EXPERIMENT_ACCESSION, VALUE FROM SCXA_CELL_GROUP
-        WHERE EXPERIMENT_ACCESSION in ($accessions4query) and
-        VARIABLE like '%cell%' and VALUE !='Not available'";
-
- print Dumper "accessions - $accessions \n";
- print Dumper "accessions4query - $accessions4query \n"; 
- print Dumper $query."\n";
- print Dumper $H_baselineCellTypeInfo;
- print Dumper $H_baselineCollectionInfo; 
-
-#print Dumper $H_baselineExperimentsInfo;
-
 # Get info from webAPI and write XMLs for baseline experiment info.
 get_and_write_experiments_info($configHash, $H_baselineExperimentsInfo, $H_baselineCellTypeInfo, $H_baselineCollectionInfo);
 


### PR DESCRIPTION
In this PR,
-  Implemented exporting single cell baseline `experiment` and gene info studies with the same schema as in GXA.
- GXA EBYE dump fix to not append metadata to gene description.

- Two files are export in this script `export_sc_atlas_ebeye_xml.pl`
  - ebeye_sc_baseline_experiments_export.xml
  - ebeye_sc_baseline_genes_export.xml

The test files are `/ebi/microarray/home/suhaib/Atlas/EBEye_dump/singlecell`

Note `ebeye_sc_baseline_genes_export.xml` contains info for lonely one gene for testing purpose.

Dependant feature branches
https://github.com/ebi-gene-expression-group/perl-atlas-modules/pull/13

https://github.com/ebi-gene-expression-group/atlas-prod/pull/190

- Jenkins set up for exports
http://193.62.54.19:30004/jenkins/view/Bulk%20data%20exports/job/C1_SC_EBEYE_Export/10/console

