### PR TITLE
Update export_open_targets.sh

### DIFF
--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -100,8 +100,7 @@ fi
 trap - INT TERM EXIT
 
 echo "Successfully fetched and validated evidence, zipping..."
-mv -nv ${destination}.tmp $destination
-gzip $destination
+mv -nv ${destination}.tmp $destination && rm -f ${$destination}.gz && gzip $destination
 
 echo "Sanity check .."
 "$scriptDir/ot_json_queries_stats.sh" -j ${destination}.gz -o $outputPath

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -54,7 +54,27 @@ listExperimentsToRetrieve | while read -r experimentAccession ; do
   echo "Retrieving experiment $experimentAccession ... "
   curl -s -w "\n" "$atlasUrl/json/experiments/$experimentAccession/evidence?$urlParams" | grep -v -e '^[[:space:]]*$' > $experimentAccession.tmp.json
   if [ -s "$experimentAccession.tmp.json" ]; then
-    opentargets_validator --schema https://raw.githubusercontent.com/opentargets/json_schema/${jsonSchemaVersion}/opentargets.json $experimentAccession.tmp.json 2>$experimentAccession.err
+  
+    # The OT validator seems to randomly hang in an unpredictable way, 
+    # which I think may have to do with pypeln and multiprocessing. The 
+    # validation shouldn't take more than a couple of seconds, so time 
+    # it out and retry
+  
+    for try in 1 2 3 4 5; do
+      timeout 10 opentargets_validator --schema https://raw.githubusercontent.com/opentargets/json_schema/${jsonSchemaVersion}/opentargets.json $experimentAccession.tmp.json 2>$experimentAccession.err
+      if [ $? -eq 124 ]; then
+        echo "Validation timed out"
+        if [ $try -eq 5 ]; then
+          echo "Validation of $experimentAccession hung too many times, failing" 1>&2
+          exit 1
+        else
+          echo "Trying again ($try)" 1>&2
+        fi
+      else
+        break
+      fi
+    done
+    
     if [ $(wc -l < $experimentAccession.err) -eq 0 ]; then
       cat $experimentAccession.tmp.json >> ${destination}.tmp
       rm $experimentAccession.tmp.json

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -91,8 +91,13 @@ listExperimentsToRetrieve | while read -r experimentAccession ; do
 done
 rm -rf experiments-exclude.tmp
 
-trap - INT TERM EXIT
+# Actually exit if the while read loop hasn't exited successfully
+if [ $? -ne 0 ]; then
+  echo "OT export failed"
+  exit 1
+fi
 
+trap - INT TERM EXIT
 
 echo "Successfully fetched and validated evidence, zipping..."
 mv -nv ${destination}.tmp $destination

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -86,6 +86,7 @@ listExperimentsToRetrieve | while read -r experimentAccession ; do
     fi
   else
     echo "WARN: $experimentAccession.tmp.json empty response"
+    rm -f "$experimentAccession.tmp.json"
   fi 
 done
 rm -rf experiments-exclude.tmp


### PR DESCRIPTION
Running the OT validator seems to randomly result in a timeout randomly when running in a singularity container.

I'll report the issue upstream, but here's the workaround I'm proposing. 

Also a couple of other fixes:

- Actually exist when validation fails (exits in 'while read' loops don't exit the whole script). I'm a bit worried this wasn't happening before.
- Tidy up files resulting from empty responses (it's not like looking at them would be informative)
- Remove the gzipped output if one of the same name already exists