### PR TITLE
Opentargets export fixes for container operation

### DIFF
--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -63,7 +63,7 @@ listExperimentsToRetrieve | while read -r experimentAccession ; do
     for try in 1 2 3 4 5; do
       timeout 10 opentargets_validator --schema https://raw.githubusercontent.com/opentargets/json_schema/${jsonSchemaVersion}/opentargets.json $experimentAccession.tmp.json 2>$experimentAccession.err
       if [ $? -eq 124 ]; then
-        echo "Validation timed out"
+        echo "Validation of $experimentAccession timed out" 1>&2
         if [ $try -eq 5 ]; then
           echo "Validation of $experimentAccession hung too many times, failing" 1>&2
           exit 1

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -89,7 +89,6 @@ listExperimentsToRetrieve | while read -r experimentAccession ; do
     rm -f "$experimentAccession.tmp.json"
   fi 
 done
-rm -rf experiments-exclude.tmp
 
 # Actually exit if the while read loop hasn't exited successfully
 if [ $? -ne 0 ]; then
@@ -97,10 +96,12 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+rm -rf experiments-exclude.tmp
+
 trap - INT TERM EXIT
 
 echo "Successfully fetched and validated evidence, zipping..."
-mv -nv ${destination}.tmp $destination && rm -f ${$destination}.gz && gzip $destination
+mv ${destination}.tmp $destination && gzip $destination
 
 echo "Sanity check .."
 "$scriptDir/ot_json_queries_stats.sh" -j ${destination}.gz -o $outputPath

--- a/bin/ot_json_queries_stats.sh
+++ b/bin/ot_json_queries_stats.sh
@@ -28,36 +28,36 @@ echo "Output path: $outputPath"
 file_name=$(basename $jsonDump | sed 's/[.].*//')
 
 json_dump_stats(){
-	json_file=$1
-    outputPath=$2
+  json_file=$1
+  outputPath=$2
 
-	file_name=$(basename $json_file | sed 's/[.].*//')
+  file_name=$(basename $json_file | sed 's/[.].*//')
 
- 	# retrieve evidences
- 	zless $json_file | jq '.evidence.unique_experiment_reference' | sort  > $outputPath/${file_name}_experiments.txt
+  # retrieve evidences
+  zcat $json_file | jq '.evidence.unique_experiment_reference' | sort  > $outputPath/${file_name}_experiments.txt
 
- 	# number of microarray that has probe id field.
- 	zless $json_file | jq '.unique_association_fields | select( has("probe_id"))' | grep "study_id"  \
-  		| grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u > $outputPath/${file_name}_micoarray.txt
+  # number of microarray that has probe id field.
+  zcat $json_file | jq '.unique_association_fields | select( has("probe_id"))' | grep "study_id"  \
+     | grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u > $outputPath/${file_name}_micoarray.txt
 
- 	# log fold change of each evidence.
- 	zless $json_file | jq '.evidence.log2_fold_change.value' >  $outputPath/${file_name}_log_fold_changes.txt
+  # log fold change of each evidence.
+  zcat $json_file | jq '.evidence.log2_fold_change.value' >  $outputPath/${file_name}_log_fold_changes.txt
 
- 	# pvalues of each evidence.
- 	zless $json_file | jq '.evidence.resource_score.value' >  $outputPath/${file_name}_pvalue.txt
+  # pvalues of each evidence.
+  zcat $json_file | jq '.evidence.resource_score.value' >  $outputPath/${file_name}_pvalue.txt
 
- 	# tabulate contrast experiments and genes associated with each study.
-	zless $json_file | jq '.unique_association_fields | .comparison_name + "  " + .study_id + "  " + .geneID' > $outputPath/${file_name}_contrast_exp_gene.txt
+  # tabulate contrast experiments and genes associated with each study.
+  zcat $json_file | jq '.unique_association_fields | .comparison_name + "  " + .study_id + "  " + .geneID' > $outputPath/${file_name}_contrast_exp_gene.txt
 
-	file_contrast=$outputPath/${file_name}_contrast_exp_gene.txt
-	exp=$(cat $file_contrast | awk -F"  " '{print $2}' | grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u)
-	for expAcc in $exp; do
-   		contrast=$(cat $file_contrast | grep "$expAcc" | awk -F"  " '{print $1}' | sort -u)
-      		for cont in $(echo -e $contrast | tr "\"" "\n" | sed '/^$/d'); do
-        			ngenes=$(cat $file_contrast | grep "$expAcc" | grep -F "$cont" | wc -l)
-         			echo -e "$expAcc\t$cont\t$ngenes"
-      		done
-	done
+  file_contrast=$outputPath/${file_name}_contrast_exp_gene.txt
+  exp=$(cat $file_contrast | awk -F"  " '{print $2}' | grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u)
+  for expAcc in $exp; do
+    contrast=$(cat $file_contrast | grep "$expAcc" | awk -F"  " '{print $1}' | sort -u)
+    for cont in $(echo -e $contrast | tr "\"" "\n" | sed '/^$/d'); do
+      ngenes=$(cat $file_contrast | grep "$expAcc" | grep -F "$cont" | wc -l)
+      echo -e "$expAcc\t$cont\t$ngenes"
+    done
+  done
 }
 
 IFS="


### PR DESCRIPTION
This PR contains a couple of small fixes to issues I introduced in https://github.com/ebi-gene-expression-group/data-exports-bulk/pull/18 (apologies).

It also amends ot_json_queries_stats.sh to:

- Fix formatting (removed some rogue tabs)
- Replace 'zless' with 'zcat'. 'zless' was failing in the container due to lack of 'less', and I think zcat is probably the right tool here anyway. 