### PR TITLE
Parse as windows-1252

### DIFF
--- a/bin/enrichEBEyeXMLDump.py
+++ b/bin/enrichEBEyeXMLDump.py
@@ -12,6 +12,7 @@ import os
 import sys
 import time
 import argparse
+import codecs
 
 class EBEyeDumpEnrichmentError(Exception):
     pass
@@ -137,7 +138,9 @@ if __name__ == "__main__":
         doctest.testmod(verbose=False) 
     else:
         t0 = time.time()
-        doc = minidom.parse(xmlFilePath)
+        with codecs.open(xmlFilePath, "r", encoding='Windows-1252') as xml:
+            doc = minidom.parse(xml)
+
         print(f"Parsed {xmlFilePath} successfully in {round(time.time() - t0)} seconds")
 
         entries = doc.getElementsByTagName('entry')


### PR DESCRIPTION
Currently the enrich script is producing errors like:

```
Traceback (most recent call last):
  File "/path/to/data-exports-bulk/bin/enrichEBEyeXMLDump.py", line 142, in <module>
    doc = minidom.parse(xml)       
  File "/usr/lib64/python3.6/xml/dom/minidom.py", line 1958, in parse
    return expatbuilder.parse(file)
  File "/usr/lib64/python3.6/xml/dom/expatbuilder.py", line 913, in parse
    result = builder.parseFile(file)
  File "/usr/lib64/python3.6/xml/dom/expatbuilder.py", line 204, in parseFile
    buffer = file.read(16*1024)
  File "/usr/lib64/python3.6/codecs.py", line 700, in read
    return self.reader.read(size)
  File "/usr/lib64/python3.6/codecs.py", line 503, in read
    newchars, decodedbytes = self.decode(data, self.errors)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x94 in position 4362: invalid start byte
```

... with our EBEYE exports. This seems to be due to the presence of non-unicode characters (e.g. the strange 'i' in naïve). The chardet utility infers that encoding is most likely Windows-1252, which I attribute to characters from external sources making it into our DB. 

Forcing that encoding seems to fix the issue. Arguably we should flip all the uses of UTF-8 in this repo as well, but maybe it's best to wait on that count. 