### PR TITLE
OT include post processes and improve performance

### DIFF
--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -101,7 +101,7 @@ rm -rf experiments-exclude.tmp
 mv ${destination}.tmp $destination
 
 echo "Sanity check .."
-"$scriptDir/ot_json_queries_stats.sh" -j ${destination} -o $outputPath
+$scriptDir/ot_json_queries_stats.sh -j ${destination} -o $outputPath
 
 # filter out based on biotypes
 json_to_process=${destination}.

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -55,12 +55,12 @@ while read -r experimentAccession ; do
   echo "Retrieving experiment $experimentAccession ... "
   curl -s -w "\n" "$evidenceURI" | grep -v -e '^[[:space:]]*$' > $experimentAccession.tmp.json
   if [ -s "$experimentAccession.tmp.json" ]; then
-  
-    # The OT validator seems to randomly hang in an unpredictable way, 
-    # which I think may have to do with pypeln and multiprocessing. The 
-    # validation shouldn't take more than a couple of seconds, so time 
+
+    # The OT validator seems to randomly hang in an unpredictable way,
+    # which I think may have to do with pypeln and multiprocessing. The
+    # validation shouldn't take more than a couple of seconds, so time
     # it out and retry
-  
+
     for try in 1 2 3 4 5 6 7 8 9 10; do
       timeout 10 opentargets_validator --schema https://raw.githubusercontent.com/opentargets/json_schema/${jsonSchemaVersion}/opentargets.json $experimentAccession.tmp.json 2>$experimentAccession.err
       if [ $? -eq 124 ]; then
@@ -74,7 +74,7 @@ while read -r experimentAccession ; do
         break
       fi
     done
-    
+
     if [ $(wc -l < $experimentAccession.err) -eq 0 ]; then
       cat $experimentAccession.tmp.json >> ${destination}.tmp
       rm $experimentAccession.tmp.json
@@ -87,22 +87,42 @@ while read -r experimentAccession ; do
   else
     echo "WARN: $experimentAccession.tmp.json empty response"
     rm -f "$experimentAccession.tmp.json"
-  fi 
+  fi
 done <<<$(listExperimentsToRetrieve)
 
 # Actually exit if the while read loop hasn't exited successfully
 if [ -n "$failed_exps" ]; then
   echo -e "WARN: OT export failed, failing experiments are: $failed_exps\nFinalising outputs anyway..."
 else
-  echo "Successfully fetched and validated evidence, zipping..."
+  echo "Successfully fetched and validated evidence, filtering and transforming..."
 fi
 
 rm -rf experiments-exclude.tmp
-mv ${destination}.tmp $destination && gzip $destination
+mv ${destination}.tmp $destination
 
 echo "Sanity check .."
-"$scriptDir/ot_json_queries_stats.sh" -j ${destination}.gz -o $outputPath
+"$scriptDir/ot_json_queries_stats.sh" -j ${destination} -o $outputPath
+
+# filter out based on biotypes
+json_to_process=${destination}.
+ensembl_genes=$ATLAS_PROD/bioentity_properties/annotations/ensembl/homo_sapiens.ensgene.tsv
+excluded_biotypes=$scriptDir/../data/excluded_biotypes.txt
+json_filtered=$( echo $json_to_process | sed s/.json/.filtered/ )".json"
+
+$scriptDir/run_json_filtering.sh $json_to_process $ensembl_genes $excluded_biotypes > $json_filtered
+
+# transform to new schema
+export INPUT_JSON=$json_filtered
+export SCHEMA_TRANSFORM=$scriptDir/../data/schema_transform.jslt
+export PROCESSED_JSON=$( echo $INPUT_JSON | sed s/.json/.transformed/ | basename )".json"
+export OUTPUT_DIR=$( dirname $json_filtered )
+export IMAGE_NAME=quay.io/ebigxa/json_schema_transform:latest
+
+$scriptDir/../run_schema_transform_container.sh singularity
 
 if [ -n "$failed_exps" ]; then
+  echo "Files ready for inspection, there was a failure, so not compressing."
   exit 1
 fi
+
+bz2 $OUTPUT_DIR/$PROCESSED_JSON

--- a/bin/export_open_targets.sh
+++ b/bin/export_open_targets.sh
@@ -125,4 +125,4 @@ if [ -n "$failed_exps" ]; then
   exit 1
 fi
 
-bz2 $OUTPUT_DIR/$PROCESSED_JSON
+bzip2 $OUTPUT_DIR/$PROCESSED_JSON

--- a/bin/ot_json_queries_stats.sh
+++ b/bin/ot_json_queries_stats.sh
@@ -34,20 +34,20 @@ json_dump_stats(){
   file_name=$(basename $json_file | sed 's/[.].*//')
 
   # retrieve evidences
-  zcat $json_file | jq '.evidence.unique_experiment_reference' | sort  > $outputPath/${file_name}_experiments.txt
+  cat $json_file | jq '.evidence.unique_experiment_reference' | sort  > $outputPath/${file_name}_experiments.txt
 
   # number of microarray that has probe id field.
-  zcat $json_file | jq '.unique_association_fields | select( has("probe_id"))' | grep "study_id"  \
+  cat $json_file | jq '.unique_association_fields | select( has("probe_id"))' | grep "study_id"  \
      | grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u > $outputPath/${file_name}_micoarray.txt
 
   # log fold change of each evidence.
-  zcat $json_file | jq '.evidence.log2_fold_change.value' >  $outputPath/${file_name}_log_fold_changes.txt
+  cat $json_file | jq '.evidence.log2_fold_change.value' >  $outputPath/${file_name}_log_fold_changes.txt
 
   # pvalues of each evidence.
-  zcat $json_file | jq '.evidence.resource_score.value' >  $outputPath/${file_name}_pvalue.txt
+  cat $json_file | jq '.evidence.resource_score.value' >  $outputPath/${file_name}_pvalue.txt
 
   # tabulate contrast experiments and genes associated with each study.
-  zcat $json_file | jq '.unique_association_fields | .comparison_name + "  " + .study_id + "  " + .geneID' > $outputPath/${file_name}_contrast_exp_gene.txt
+  cat $json_file | jq '.unique_association_fields | .comparison_name + "  " + .study_id + "  " + .geneID' > $outputPath/${file_name}_contrast_exp_gene.txt
 
   file_contrast=$outputPath/${file_name}_contrast_exp_gene.txt
   exp=$(cat $file_contrast | awk -F"  " '{print $2}' | grep  -oe 'E-[[:upper:]]*-[[:digit:]]*' | sort -u)

--- a/bin/run_json_filtering.sh
+++ b/bin/run_json_filtering.sh
@@ -5,22 +5,21 @@ json_to_process=$1
 ensembl_genes=$2
 excluded_biotypes=$3
 
-[  -z $json_to_process ] && echo "Error: JSON file to process must be defined." && exit 1 
-[  -z $ensembl_genes ] && echo "Error: Ensembl genes file must be defined." && exit 1 
-[  -z $excluded_biotypes ] && echo "Error: excluded biotypes file must be defined." && exit 1 
+[  -z $json_to_process ] && echo "Error: JSON file to process must be defined." && exit 1
+[  -z $ensembl_genes ] && echo "Error: Ensembl genes file must be defined." && exit 1
+[  -z $excluded_biotypes ] && echo "Error: excluded biotypes file must be defined." && exit 1
 
 # filter evidence strings where target.activity is unknown
 [ -f tmp.json ] && rm -f tmp.json
-while IFS='' read -r line; do
-    target_activity=$(echo $line | jq -r ".target.activity" | sed 's:.*/::')
-    [ ! $target_activity == "unknown" ] && [ ! $target_activity == "" ] && echo $line | jq -c . >> tmp.json
-    [ $target_activity == "unknown" ] && echo $line | jq -c . >> data/cttv010-2021-03-03_no_activity.json
-done < $json_to_process
+[ -f tmp.discarded_activity.json ] && rm -f tmp.discarded_activity.json
+
+jq -c '. | select( .target.activity == "" or ( .target.activity | contains("unknown")) | not )' $json_to_process > tmp.json
+jq -c '. | select( .target.activity == "" or ( .target.activity | contains("unknown")) )' $json_to_process > tmp.discarded_activity.json
 
 if [[ -f tmp.json ]]; then
     # find genes that have correct biotype
     cat $ensembl_genes | grep -v -f $excluded_biotypes | grep -v "ensgene" | cut -f 1,1 > filtered_genes.txt
-    # filter out genes with unwanted biotype 
+    # filter out genes with unwanted biotype
     grep -f filtered_genes.txt tmp.json
 else
     echo "No evidence lines with target.activity detected"

--- a/run_schema_transform_container.sh
+++ b/run_schema_transform_container.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 
-[ -z ${INPUT_JSON+x} ] && echo "Error: variable INPUT_JSON is not defined." && exit 1 
-[ -z ${SCHEMA_TRANSFORM+x} ] && echo "Error: variable SCHEMA_TRANSFORM is not defined." && exit 1 
+[ -z ${INPUT_JSON+x} ] && echo "Error: variable INPUT_JSON is not defined." && exit 1
+[ -z ${SCHEMA_TRANSFORM+x} ] && echo "Error: variable SCHEMA_TRANSFORM is not defined." && exit 1
 [ -z ${PROCESSED_JSON+x} ] && PROCESSED_JSON="processed_output.json"
 [ -z ${IMAGE_NAME+x} ] && IMAGE_NAME="json_schema_transform"
 
@@ -19,7 +19,6 @@ elif [ $container == "singularity" ]; then
     singularity exec -B $INPUT_JSON:/data/input.json \
                -B $SCHEMA_TRANSFORM:/data/schema_transform.jslt \
                -B $OUTPUT_DIR:/data/outputs \
-               --env PROCESSED_JSON=$PROCESSED_JSON \
                docker://$IMAGE_NAME /src/run_schema_transform.sh
 else
     echo "Variable 'container' must be set to 'docker' or 'singularity', please provide one of them as first argument." && exit 1


### PR DESCRIPTION
This PR:

- Massively reduces filtering time from hours to minutes by using only jq instead of subsequent bash/jq calls.
- Calls filtering after main OT dump to use biotypes desired for targets
- Calls transformation through JSLT after filtering to adapt to new schema.