### PR TITLE
Replace Peach API with BioStudies in export_atlas_ebeye_xml.pl

### DIFF
--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -913,7 +913,7 @@ sub get_privacy{
     my $privacy;
     
     if( $response->is_success ) {
-        my $data = decode_json($response->content);
+        my $data = parse_json(decode ('UTF-8', $response->content));
         my $total_hit = $data->{totalHits};
  	    if ($total_hit > 0){
             my $is_public = $data->{hits}[0]->{isPublic};

--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -906,19 +906,52 @@ sub get_privacy{
   my ( $expId ) =  @_;
 
   if ( ! exists $exptPrivacies->{ $expId } ){
-    my $url = "http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=$expId";
+    my $url = "https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=$expId";
     my $ua = LWP::UserAgent->new;
-    my $response = $ua->get($url)->content;
-    my ($privacy) = $response =~ m/privacy:(\w+)\s/g;
+    my $response = $ua->get($url);
+    
+    my $privacy;
+    
+    if( $response->is_success ) {
+        my $data = decode_json($response->content);
+        my $total_hit = $data->{totalHits};
+ 	    if ($total_hit > 0){
+            my $is_public = $data->{hits}[0]->{isPublic};
 
-    if (! $privacy ){
-      $privacy='unknown';
+            if ($is_public) {
+                $privacy="public";
+            } else {
+                $privacy="private";
+            }
+        }
+        else{
+            $logger->error(
+                "Accession ",
+                $expId,
+                " not found: \"",
+                $response->decoded_content,
+                "\". Defaulting to unknown."
+                );
+
+                $privacy="unknown";
+
+ 	    }
     }
-    elsif ($privacy ne 'public' && $privacy ne 'private'){
-      $logger->logdie( "Invalid privacy \"$privacy\" for \"$expId\"" );
-    }
-    $exptPrivacies->{ $expId } = $privacy;
+    
+    else {
+     	$logger->error(
+              "Problem querying ArrayExpress for $expId privacy status: ",
+              $response->status_line,
+              ". Defaulting to unknown."
+          );
+
+ 	$privacy="unknown";
+   
+    
   }
+  
+  $exptPrivacies->{ $expId } = $privacy;
+  
   return $exptPrivacies->{ $expId };
 }
 

--- a/bin/export_atlas_ebeye_xml.pl
+++ b/bin/export_atlas_ebeye_xml.pl
@@ -948,10 +948,10 @@ sub get_privacy{
  	$privacy="unknown";
    
     
+    }
+  
+    $exptPrivacies->{ $expId } = $privacy;
   }
-  
-  $exptPrivacies->{ $expId } = $privacy;
-  
   return $exptPrivacies->{ $expId };
 }
 


### PR DESCRIPTION
The goal here is to fix export_atlas_ebeye_xml.pl

As the Peach API is deprecated, the function that returns 'public' or 'private' status will fail:

```
sub get_privacy{
    ...
     my $url = "http://peach.ebi.ac.uk:8480/api/privacy.txt?acc=$expId";
     my $ua = LWP::UserAgent->new;
     my $response = $ua->get($url)->content;
    ...
}
```
In this PR https://github.com/ebi-gene-expression-group/atlas-prod/pull/255 we solve it by using an internal file and when not available querying the [BioStudies API](https://www.ebi.ac.uk/biostudies/help). 

The difference now is that the data resulting from the query comes in JSON format , e.g the following will return true:

curl -sS "https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=E-MTAB-10293" | jq .hits[0] | jq .isPublic