### PR TITLE
Export unique UniProt IDs in Atlas as Atlas search links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module provides functionality for the Atlas Production data exports process
 - ChEBI export.
 - EBEYE export.
 - Large Atlas tar.gz export for bulk.
+- UniProt-ID export
 
 Exports are normally executed between the pre-release date and the release date,
 as they require release data loaded in a wwwdev or equivalent web deployment.

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -12,8 +12,8 @@
 
 atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"
 ATLAS_UNIPROT_EXPORT_FILE=${$1:-$ATLAS_UNIPROT_EXPORT_FILE}
-
-rm -f $ATLAS_UNIPROT_EXPORT_FILE
+today=$( eval date +%F_%Hh%Mm%Ss )
+datedExportFile="${ATLAS_UNIPROT_EXPORT_FILE}.${today}"
 
 # Get all unique UNIPROT IDs in bulk-analytics
 uniprot_ids=$(curl -u $SOLR_USER:$SOLR_PASS $atlasUniqueUniprotUrl | jq '.facet_counts.facet_fields["keyword_uniprot"]' | grep -Po '(?<=\")[a-z0-9]+')
@@ -21,5 +21,8 @@ uniprot_ids=$(curl -u $SOLR_USER:$SOLR_PASS $atlasUniqueUniprotUrl | jq '.facet_
 # Generate Atlas search links
 for uniprot_id in $uniprot_ids; do
     url="https://wwwdev.ebi.ac.uk/gxa/search?geneQuery=[{%22value%22:%22${uniprot_id}%22,%20%22category%22:%22uniprot%22}]"
-    echo -e "${uniprot_id}\t${url}" >> $ATLAS_UNIPROT_EXPORT_FILE
+    echo -e "${uniprot_id}\t${url}" >> $datedExportFile
 done
+
+rm -f $ATLAS_UNIPROT_EXPORT_FILE
+ln -s $ATLAS_UNIPROT_EXPORT_FILE $datedExportFile

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -2,7 +2,7 @@
 
 # What this script does:
 # 1. Gets all unique UniProt IDs in Atlas bulk-analytics collection
-# 2. Generates an Atlas search linnk for each UniProt ID
+# 2. Generates an Atlas search link for each UniProt ID
 # 3. Writes everything to file
 
 # Caveats:

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -17,7 +17,7 @@ command -v jq &>/dev/null || { echo "jq is not installed."; exit 1; }
 
 
 atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"
-ATLAS_UNIPROT_EXPORT_FILE=${$ATLAS_UNIPROT_EXPORT_FILE:-atlas_uniprot_searces.tsv}
+ATLAS_UNIPROT_EXPORT_FILE=${$ATLAS_UNIPROT_EXPORT_FILE:-atlas_uniprot_searches.tsv}
 today=$( eval date +%F_%Hh%Mm%Ss )
 datedExportFile="${ATLAS_UNIPROT_EXPORT_FILE}.${today}"
 

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -8,6 +8,12 @@
 # Caveats:
 # 1. Only works for bulk-analytics for now. There seems to be no  in scxa solr (???) still waiting for reply from devs
 # 2. Only gets 100 unique uniprot IDs...seems odd.  Still investigating this.
+# Check that relevant env vars are set
+[ -z ${SOLR_HOST+x} ] && echo "Env var SOLR_HOST needs to be defined." && exit 1
+[ -z ${SOLR_USER+x} ] && echo "Env var SOLR_USER needs to be defined." && exit 1
+[ -z ${SOLR_PASS+x} ] && echo "Env var SOLR_PASS needs to be defined." && exit 1
+
+command -v jq &>/dev/null || { echo "jq is not installed."; exit 1; }
 
 
 atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -16,7 +16,7 @@
 command -v jq &>/dev/null || { echo "jq is not installed."; exit 1; }
 
 
-atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"
+atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0&facet.limit=-1"
 ATLAS_UNIPROT_EXPORT_FILE=${$ATLAS_UNIPROT_EXPORT_FILE:-atlas_uniprot_searches.tsv}
 today=$( eval date +%F_%Hh%Mm%Ss )
 datedExportFile="${ATLAS_UNIPROT_EXPORT_FILE}.${today}"

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -17,7 +17,7 @@ command -v jq &>/dev/null || { echo "jq is not installed."; exit 1; }
 
 
 atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"
-ATLAS_UNIPROT_EXPORT_FILE=${$1:-$ATLAS_UNIPROT_EXPORT_FILE}
+ATLAS_UNIPROT_EXPORT_FILE=${$ATLAS_UNIPROT_EXPORT_FILE:-atlas_uniprot_searces.tsv}
 today=$( eval date +%F_%Hh%Mm%Ss )
 datedExportFile="${ATLAS_UNIPROT_EXPORT_FILE}.${today}"
 

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# What this script does:
+# 1. Gets all unique UniProt IDs in Atlas bulk-analytics collection
+# 2. Generates an Atlas search linnk for each UniProt ID
+# 3. Writes everything to file
+
+# Caveats:
+# 1. Only works for bulk-analytics for now. There seems to be no  in scxa solr (???) still waiting for reply from devs
+# 2. Only gets 100 unique uniprot IDs...seems odd.  Still investigating this.
+
+
+atlasUniqueUniprotUrl="http://${SOLR_HOST}/solr/bulk-analytics-v1/select?facet.field=keyword_uniprot&facet=on&q=*:*&rows=0&start=0"
+ATLAS_UNIPROT_EXPORT_FILE=${$1:-$ATLAS_UNIPROT_EXPORT_FILE}
+
+rm -f $ATLAS_UNIPROT_EXPORT_FILE
+
+# Get all unique UNIPROT IDs in bulk-analytics
+uniprot_ids=$(curl -u $SOLR_USER:$SOLR_PASS $atlasUniqueUniprotUrl | jq '.facet_counts.facet_fields["keyword_uniprot"]' | grep -Po '(?<=\")[a-z0-9]+')
+
+# Generate Atlas search links
+for uniprot_id in $uniprot_ids; do
+    url="https://wwwdev.ebi.ac.uk/gxa/search?geneQuery=[{%22value%22:%22${uniprot_id}%22,%20%22category%22:%22uniprot%22}]"
+    echo -e "${uniprot_id}\t${url}" >> $ATLAS_UNIPROT_EXPORT_FILE
+done

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -26,7 +26,7 @@ uniprot_ids=$(curl -u $SOLR_USER:$SOLR_PASS $atlasUniqueUniprotUrl | jq '.facet_
 
 # Generate Atlas search links
 for uniprot_id in $uniprot_ids; do
-    url="https://wwwdev.ebi.ac.uk/gxa/search?geneQuery=[{%22value%22:%22${uniprot_id}%22,%20%22category%22:%22uniprot%22}]"
+    url="https://www.ebi.ac.uk/gxa/search?geneQuery=[{%22value%22:%22${uniprot_id}%22,%20%22category%22:%22uniprot%22}]"
     echo -e "${uniprot_id}\t${url}" >> $datedExportFile
 done
 

--- a/bin/export_atlas_uniprot.sh
+++ b/bin/export_atlas_uniprot.sh
@@ -31,4 +31,4 @@ for uniprot_id in $uniprot_ids; do
 done
 
 rm -f $ATLAS_UNIPROT_EXPORT_FILE
-ln -s $ATLAS_UNIPROT_EXPORT_FILE $datedExportFile
+ln -s $datedExportFile $ATLAS_UNIPROT_EXPORT_FILE


### PR DESCRIPTION
This adds a feature to export unique UniProt IDs in Atlas and their corresponding Atlas search links.  This currently only works for GXA.  